### PR TITLE
Fix Vite base path and document GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Applicazione web per il corso di **Sistemi Operativi 2**, focalizzata sulla gest
   npm run preview
   ```
 
+## Distribuzione su GitHub Pages
+- Eseguire la build:
+  ```bash
+  npm run build
+  ```
+- Caricare il contenuto della cartella `dist` nel branch `gh-pages` del repository.
+- La configurazione Vite utilizza un `base` relativo, quindi l'app funzionerà correttamente sia in locale sia su GitHub Pages.
+
 ## Struttura del progetto
 - `src/` – componenti e logica dell'applicazione
 - `index.html` – punto di ingresso dell'app

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/SO2_webapp/',        // 👈 necessario per GitHub Pages (project page)
+  // Use a relative base so the app works on GitHub Pages and in local previews
+  base: './',
   server: { host: true, port: 5173 },
   preview: { host: true, port: 4173 },
 })


### PR DESCRIPTION
## Summary
- use relative base path in Vite config so app works locally and on GitHub Pages
- document steps to deploy built `dist` folder to GitHub Pages

## Testing
- `npm run build`
- `npm run preview -- --host`

------
https://chatgpt.com/codex/tasks/task_e_689de65ae8b08333bd927b2cc29052bd