### PR TITLE
Fix Vite base path and React imports for Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Applicazione web per il corso di **Sistemi Operativi 2**, focalizzata sulla gest
   npm run preview
   ```
 
+## Distribuzione su GitHub Pages
+- Eseguire la build:
+  ```bash
+  npm run build
+  ```
+- Caricare il contenuto della cartella `dist` nel branch `gh-pages` del repository.
+- La configurazione Vite utilizza un `base` relativo, quindi l'app funzionerà correttamente sia in locale sia su GitHub Pages.
+
 ## Struttura del progetto
 - `src/` – componenti e logica dell'applicazione
 - `index.html` – punto di ingresso dell'app

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
+        "@types/react": "^18.2.21",
+        "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
@@ -1097,6 +1099,34 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1224,6 +1254,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
     "@tailwindcss/postcss": "^4.1.12",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.21",

--- a/src/LessonsApp.tsx
+++ b/src/LessonsApp.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, type FC } from 'react';
 import {
   ChevronRight,
   ChevronLeft,
@@ -18,7 +18,7 @@ import {
  * A small theme toggle button that flips the `dark` class on the root document element.
  * It persists the selection in localStorage and respects the user's system preference by default.
  */
-const ThemeToggle: React.FC = () => {
+const ThemeToggle: FC = () => {
   const [theme, setTheme] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('theme');
@@ -56,7 +56,7 @@ const ThemeToggle: React.FC = () => {
   );
 };
 
-const LessonsApp: React.FC = () => {
+const LessonsApp: FC = () => {
   const [selectedLesson, setSelectedLesson] = useState<number | null>(null);
   const [selectedSection, setSelectedSection] = useState<string | null>(null);
   const [showSectionMenu, setShowSectionMenu] = useState(false);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import LessonsApp from './LessonsApp';
 import './index.css';
 
 // Entry point for the OS Lessons App with dark mode support.
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
+  <StrictMode>
     <LessonsApp />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/SO2_webapp/',        // 👈 necessario per GitHub Pages (project page)
+  // Use a relative base so the app works on GitHub Pages and in local previews
+  base: './',
   server: { host: true, port: 5173 },
   preview: { host: true, port: 4173 },
 })


### PR DESCRIPTION
## Summary
- use relative base path in Vite config so app works locally and on GitHub Pages
- document steps to deploy built `dist` folder to GitHub Pages
- refactor TSX files to use named React imports and component types
- add React type declarations to resolve TypeScript import errors

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run build`
- `npm run preview -- --host`


------
https://chatgpt.com/codex/tasks/task_e_689de65ae8b08333bd927b2cc29052bd